### PR TITLE
Update pier92 station

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,0 @@
-# riverfork
-East River NOAA tidal currents
-
-TBD. Possibly contribute-to/extend Erik's cool widget/app => https://github.com/nykp/noaa-currents 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# riverfork
+East River NOAA tidal currents
+
+TBD. Possibly contribute-to/extend Erik's cool widget/app => https://github.com/nykp/noaa-currents 

--- a/nykp_conditions/noaa_currents.py
+++ b/nykp_conditions/noaa_currents.py
@@ -93,7 +93,7 @@ class Station:
     depth: Optional[str] = None
 
 
-HUDSON_RIVER_PIER_92 = Station('Hudson River, Pier 92', 'NYH1928', '6 feet')
+HUDSON_RIVER_PIER_92 = Station('Hudson River, Pier 92', 'NYH1928_12', '6 feet')
 HUDSON_RIVER_ENTRANCE = Station('Hudson River Entrance', 'NYH1927_13')
 default_nykp_station = HUDSON_RIVER_PIER_92
 


### PR DESCRIPTION
Erik – it appears your App within NYKP Slack

https://app.slack.com/client/TGAB93JAC/C03JB9JSFSA

 is pulling in NOAA data for Pier 92 but at a depth of 35 feet… NOT what I believe you intended to pull/display -- right? Ie. – I presume you really want to display NOAA CURRENT data from a Depth of 6 feet (not 35 feet).      

Hudson River, Pier 92 (NYH1928) Depth: 6 feet
 https://tidesandcurrents.noaa.gov/noaacurrents/Predictions?id=NYH1928_12   
 
 Hudson River, Pier 92 (NYH1928) Depth: 35 feet = Station 
 https://tidesandcurrents.noaa.gov/noaacurrents/Predictions?id=NYH1928_3

<img width="1002" alt="Erik_NOAA_widget_pulling_in_wrong_data" src="https://github.com/nykp/noaa-currents/assets/423872/fecf8550-c451-4bf8-a212-53f2c1896de8">

<img width="1113" alt="Erik_NOAA_widget_pulling_in_wrong_data_02" src="https://github.com/nykp/noaa-currents/assets/423872/27c2a664-a4b7-4eb9-a112-3b37d757cd23">


